### PR TITLE
Add configurable cluster domain support for non-standard Kubernetes environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,32 @@ In that go template, the following variables may be used:
 - `.tlsEnabled` (whether TLS encryption is enabled or not)
 - `.caData` (CA certificate that clients may use to connect to valkey)
 
+### Custom cluster domain
+
+By default, Valkey services are accessed using DNS names with the `cluster.local` domain suffix (e.g., `valkey-test.namespace.svc.cluster.local`). 
+If your Kubernetes cluster uses a custom cluster domain, you can configure it using the `spec.clusterDomain` field:
+
+```yaml
+apiVersion: cache.cs.sap.com/v1alpha1
+kind: Valkey
+metadata:
+  name: test
+spec:
+  clusterDomain: kube.prod
+  replicas: 3
+  sentinel:
+    enabled: true
+```
+
+This will result in DNS names like:
+- `valkey-test.namespace.svc.kube.prod` instead of `valkey-test.namespace.svc.cluster.local`
+
+The cluster domain value is used for:
+- Service DNS names in the binding secret
+- TLS certificate DNS names (when using cert-manager)
+
+If not specified, the default value `cluster.local` is used for backward compatibility.
+
 ### Customize pod settings
 
 The following attributes allow to tweak the created pods/containers:

--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -30,8 +30,11 @@ type ValkeySpec struct {
 	TLS                                     *TLSProperties         `json:"tls,omitempty"`
 	Persistence                             *PersistenceProperties `json:"persistence,omitempty"`
 	Binding                                 *BindingProperties     `json:"binding,omitempty"`
-	ExtraEnvVars                            []corev1.EnvVar        `json:"extraEnvVars,omitempty"`
-	ExtraFlags                              []string               `json:"extraFlags,omitempty"`
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
+	// +kubebuilder:default="cluster.local"
+	ClusterDomain string          `json:"clusterDomain,omitempty"`
+	ExtraEnvVars  []corev1.EnvVar `json:"extraEnvVars,omitempty"`
+	ExtraFlags    []string        `json:"extraFlags,omitempty"`
 }
 
 // SentinelProperties models attributes of the sentinel sidecar

--- a/crds/cache.cs.sap.com_valkeys.yaml
+++ b/crds/cache.cs.sap.com_valkeys.yaml
@@ -967,6 +967,10 @@ spec:
                   template:
                     type: string
                 type: object
+              clusterDomain:
+                default: cluster.local
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                type: string
               extraEnvVars:
                 items:
                   description: EnvVar represents an environment variable present in

--- a/examples/custom-cluster-domain.yaml
+++ b/examples/custom-cluster-domain.yaml
@@ -1,0 +1,15 @@
+apiVersion: cache.cs.sap.com/v1alpha1
+kind: Valkey
+metadata:
+  name: valkey-custom-domain
+spec:
+  # Custom cluster domain for environments that don't use the default cluster.local
+  clusterDomain: kube.prod
+  replicas: 3
+  sentinel:
+    enabled: true
+  metrics:
+    enabled: true
+  tls:
+    enabled: true
+    certManager: {}

--- a/pkg/operator/binding.go
+++ b/pkg/operator/binding.go
@@ -23,17 +23,23 @@ import (
 func reconcileBinding(ctx context.Context, client client.Client, valkey *operatorv1alpha1.Valkey) error {
 	params := make(map[string]any)
 
+	// Use cluster domain from spec, defaulting to "cluster.local" for backward compatibility
+	clusterDomain := valkey.Spec.ClusterDomain
+	if clusterDomain == "" {
+		clusterDomain = "cluster.local"
+	}
+
 	if valkey.Spec.Sentinel != nil && valkey.Spec.Sentinel.Enabled {
 		params["sentinelEnabled"] = true
-		params["host"] = fmt.Sprintf("valkey-%s.%s.svc.cluster.local", valkey.Name, valkey.Namespace)
+		params["host"] = fmt.Sprintf("valkey-%s.%s.svc.%s", valkey.Name, valkey.Namespace, clusterDomain)
 		params["port"] = 6379
-		params["sentinelHost"] = fmt.Sprintf("valkey-%s.%s.svc.cluster.local", valkey.Name, valkey.Namespace)
+		params["sentinelHost"] = fmt.Sprintf("valkey-%s.%s.svc.%s", valkey.Name, valkey.Namespace, clusterDomain)
 		params["sentinelPort"] = 26379
 		params["primaryName"] = "myprimary"
 	} else {
-		params["primaryHost"] = fmt.Sprintf("valkey-%s-primary.%s.svc.cluster.local", valkey.Name, valkey.Namespace)
+		params["primaryHost"] = fmt.Sprintf("valkey-%s-primary.%s.svc.%s", valkey.Name, valkey.Namespace, clusterDomain)
 		params["primaryPort"] = 6379
-		params["replicaHost"] = fmt.Sprintf("valkey-%s-replicas.%s.svc.cluster.local", valkey.Name, valkey.Namespace)
+		params["replicaHost"] = fmt.Sprintf("valkey-%s-replicas.%s.svc.%s", valkey.Name, valkey.Namespace, clusterDomain)
 		params["replicaPort"] = 6379
 	}
 

--- a/pkg/operator/data/parameters.yaml
+++ b/pkg/operator/data/parameters.yaml
@@ -14,6 +14,8 @@ fullnameOverride: {{ $fullname }}
 {{- $bindingSecretName = printf "%s-binding" $fullname }}
 {{- end }}
 
+{{- $clusterDomain := (dig "clusterDomain" "cluster.local" .) }}
+
 image:
   repository: bitnamilegacy/valkey
   {{- with .Version}}
@@ -232,6 +234,8 @@ tls:
   {{- end }}
 {{- end }}
 
+clusterDomain: {{ $clusterDomain }}
+
 networkPolicy:
   enabled: true
   extraEgress:
@@ -256,27 +260,27 @@ extraDeploy:
     secretName: {{ printf "%s-tls" $fullname }}
     commonName: {{ $fullname }}
     dnsNames:
-    - '{{ printf "%s.%s.svc.cluster.local" $fullname .Namespace }}'
+    - '{{ printf "%s.%s.svc.%s" $fullname .Namespace $clusterDomain }}'
     - '{{ printf "%s.%s.svc" $fullname .Namespace }}'
     - '{{ printf "%s.%s" $fullname .Namespace }}'
     - '{{ printf "%s" $fullname }}'
-    - '{{ printf "*.%s.%s.svc.cluster.local" $fullname .Namespace }}'
+    - '{{ printf "*.%s.%s.svc.%s" $fullname .Namespace $clusterDomain }}'
     - '{{ printf "*.%s.%s.svc" $fullname .Namespace }}'
     - '{{ printf "*.%s.%s" $fullname .Namespace }}'
     - '{{ printf "*.%s" $fullname }}'
-    - '{{ printf "%s-primary.%s.svc.cluster.local" $fullname .Namespace }}'
+    - '{{ printf "%s-primary.%s.svc.%s" $fullname .Namespace $clusterDomain }}'
     - '{{ printf "%s-primary.%s.svc" $fullname .Namespace }}'
     - '{{ printf "%s-primary.%s" $fullname .Namespace }}'
     - '{{ printf "%s-primary" $fullname }}'
-    - '{{ printf "*.%s-primary.%s.svc.cluster.local" $fullname .Namespace }}'
+    - '{{ printf "*.%s-primary.%s.svc.%s" $fullname .Namespace $clusterDomain }}'
     - '{{ printf "*.%s-primary.%s.svc" $fullname .Namespace }}'
     - '{{ printf "*.%s-primary.%s" $fullname .Namespace }}'
     - '{{ printf "*.%s-primary" $fullname }}'
-    - '{{ printf "%s-headless.%s.svc.cluster.local" $fullname .Namespace }}'
+    - '{{ printf "%s-headless.%s.svc.%s" $fullname .Namespace $clusterDomain }}'
     - '{{ printf "%s-headless.%s.svc" $fullname .Namespace }}'
     - '{{ printf "%s-headless.%s" $fullname .Namespace }}'
     - '{{ printf "%s-headless" $fullname }}'
-    - '{{ printf "*.%s-headless.%s.svc.cluster.local" $fullname .Namespace }}'
+    - '{{ printf "*.%s-headless.%s.svc.%s" $fullname .Namespace $clusterDomain }}'
     - '{{ printf "*.%s-headless.%s.svc" $fullname .Namespace }}'
     - '{{ printf "*.%s-headless.%s" $fullname .Namespace }}'
     - '{{ printf "*.%s-headless" $fullname }}'


### PR DESCRIPTION
This PR solves https://github.com/SAP/valkey-operator/issues/6#issuecomment-3575616975

The operator hardcoded `cluster.local` as the DNS suffix, breaking deployments in Kubernetes clusters using custom domains (e.g., `kube.prod`, `k8s.mycorp.local`). This caused DNS resolution failures in Sentinel and Valkey HA configurations.

**Changes:**

- **API (`api/v1alpha1/types.go`)**: Added optional `ClusterDomain` field to `ValkeySpec` with DNS-compliant validation pattern and default value `cluster.local`

- **Binding logic (`pkg/operator/binding.go`)**: Replaced hardcoded DNS suffix with `valkey.Spec.ClusterDomain` in service hostname construction for both sentinel and non-sentinel modes

- **Helm integration (`pkg/operator/data/parameters.yaml`)**: Passed `clusterDomain` parameter to Bitnami chart and updated TLS certificate DNS SANs to use configurable domain

- **Documentation**: Added usage example and field description to README

**Usage:**

```yaml
apiVersion: cache.cs.sap.com/v1alpha1
kind: Valkey
metadata:
  name: valkey-prod
spec:
  clusterDomain: kube.prod
  replicas: 3
  sentinel:
    enabled: true
```

Generates DNS names: `valkey-prod.namespace.svc.kube.prod` instead of `cluster.local`

Backward compatible—existing deployments continue using `cluster.local` by default.

_Disclaimer : This PR was largely written with Copilot/Claude 4.5_
