### PR TITLE
fix(operator): imageRegistry field to override container registry

### DIFF
--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -19,6 +19,9 @@ import (
 // ValkeySpec defines the desired state of Valkey
 type ValkeySpec struct {
 	Version string `json:"version,omitempty"`
+	// ImageRegistry overrides the container registry for all Valkey images (e.g. a private Artifactory mirror).
+	// +optional
+	ImageRegistry string `json:"imageRegistry,omitempty"`
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:default=1
 	Replicas                                int `json:"replicas,omitempty"`

--- a/crds/cache.cs.sap.com_valkeys.yaml
+++ b/crds/cache.cs.sap.com_valkeys.yaml
@@ -1127,6 +1127,10 @@ spec:
                 items:
                   type: string
                 type: array
+              imageRegistry:
+                description: ImageRegistry overrides the container registry for all
+                  Valkey images (e.g. a private Artifactory mirror).
+                type: string
               metrics:
                 description: MetricsProperties models attributes of the metrics exporter
                   sidecar

--- a/pkg/operator/data/parameters.yaml
+++ b/pkg/operator/data/parameters.yaml
@@ -20,11 +20,16 @@ image:
   tag: {{ . }}
   {{- end }}
 
-{{- if $persistenceEnabled }}
-{{- with .persistence.storageClass }}
+{{- if or .imageRegistry (and $persistenceEnabled .persistence.storageClass) }}
 global:
+  {{- with .imageRegistry }}
+  imageRegistry: {{ . }}
+  {{- end }}
+  {{- if $persistenceEnabled }}
+  {{- with .persistence.storageClass }}
   storageClass: {{ . }}
-{{- end }}
+  {{- end }}
+  {{- end }}
 {{- end }}
 
 {{- if gt .replicas 1 }}


### PR DESCRIPTION
Closes #43

- Adds `imageRegistry` field to ValkeySpec to override the container registry for all Valkey images
- Enables use of private container registries without source modifications